### PR TITLE
Allow users to create schema w/out Virgil

### DIFF
--- a/src/schema/trigger_insert.cdl
+++ b/src/schema/trigger_insert.cdl
@@ -1,0 +1,5 @@
+use Triggers;
+
+set Triggers['dummy:book']['com.hmsonline.cassandra.triggers.DisabledTrigger']='disabled';
+
+set Triggers['dummy:book']['com.hmsonline.cassandra.triggers.TestTrigger']='enabled';

--- a/src/schema/trigger_schema.cdl
+++ b/src/schema/trigger_schema.cdl
@@ -1,0 +1,22 @@
+create keyspace triggers;
+
+use triggers;
+
+create column family CommitLog
+  with column_type = 'Standard'
+  and comparator = 'UTF8Type'
+  and default_validation_class = 'UTF8Type'
+  and key_validation_class = 'UTF8Type';
+
+create column family Configuration
+  with column_type = 'Standard'
+  and comparator = 'UTF8Type'
+  and default_validation_class = 'UTF8Type'
+  and key_validation_class = 'UTF8Type';
+
+create column family Triggers
+  with column_type = 'Standard'
+  and comparator = 'UTF8Type'
+  and default_validation_class = 'UTF8Type'
+  and key_validation_class = 'UTF8Type';
+


### PR DESCRIPTION
Added schema creation files for users that may not want to depend on Virgil.

May need to be adjusted to create any additional indexes that might be required on CommitLog.
