### PR TITLE
Fix for issue 40 - "LogEntryStore can generate invalid column family name"

### DIFF
--- a/src/main/java/com/hmsonline/cassandra/triggers/dao/LogEntryStore.java
+++ b/src/main/java/com/hmsonline/cassandra/triggers/dao/LogEntryStore.java
@@ -26,6 +26,7 @@ public abstract class LogEntryStore extends CassandraStore {
     private static Logger logger = LoggerFactory.getLogger(LogEntryStore.class);
     private static String hostName = null;
     private static final int DELETE_PRIORITY = 3;
+    private static final String INVALID_CF_NAME_CHAR = "[^a-zA-Z0-9_]";
 
     protected LogEntryStore(String keyspace, String columnFamily) throws Exception {
         super(keyspace, columnFamily + "_" + getHostName());
@@ -85,9 +86,7 @@ public abstract class LogEntryStore extends CassandraStore {
                     }
                 }
             }
-            hostName = hostName.replaceAll(":", "_");
-            hostName = hostName.replaceAll("%", "_");
-            hostName = hostName.replaceAll("\\.", "_");
+            hostName = hostName.replaceAll(INVALID_CF_NAME_CHAR, "_");
         }
         return hostName;
     }

--- a/src/test/java/com/hmsonline/cassandra/triggers/dao/LogEntryStoreTest.java
+++ b/src/test/java/com/hmsonline/cassandra/triggers/dao/LogEntryStoreTest.java
@@ -1,0 +1,33 @@
+package com.hmsonline.cassandra.triggers.dao;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+/**
+ * Unit test of {@link LogEntryStore}.
+ *
+ * @author Andrew Swan
+ */
+public class LogEntryStoreTest {
+    
+    private static final String INVALID_NAME_MESSAGE = "Host name '%s' does not match %s";
+    
+    // The pattern that a column family name must match in order to be valid
+    private static final Pattern CF_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9_]+");
+
+    @Test
+    public void hostNameShouldBeValidWithinColumnFamilyName() throws Exception {
+        // Invoke
+        String hostName = LogEntryStore.getHostName();
+        
+        // Check
+        Matcher matcher = CF_NAME_PATTERN.matcher(hostName);
+        String errorMessage =
+                String.format(INVALID_NAME_MESSAGE, hostName, CF_NAME_PATTERN);
+        assertTrue(errorMessage, matcher.matches());
+    }
+}


### PR DESCRIPTION
This pull request fixes [issue 40](https://github.com/hmsonline/cassandra-triggers/issues/40) by replacing all invalid characters with an underscore (previously only colon, percent, and dot were being replaced).

A JUnit test case is included.
