### PR TITLE
Add version of maven-compiler-plugin to POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.5.1</version>
 				<configuration>
 					<source>1.5</source>
 					<target>1.5</target>


### PR DESCRIPTION
It's advisable for the POM to specify a version for each plugin, in order to ensure a repeatable build. This change also removes the associated Maven warning from the console at build time.
